### PR TITLE
Expand template service

### DIFF
--- a/admin/admin_theme.py
+++ b/admin/admin_theme.py
@@ -12,7 +12,7 @@ from core.database import db_session
 from core.models import Config
 from core.template import (
     AdminTemplates, TEMPLATES, TemplateService, UserTemplates,
-    get_current_theme, get_theme_list, get_theme_info, register_theme_statics,
+    get_current_theme, get_theme_list, get_theme_info,
 )
 from lib.dependency.dependencies import validate_super_admin, validate_theme
 
@@ -110,7 +110,7 @@ async def theme_update(
             os.unlink(file_path)
 
     # 테마 관련 정적 파일을 등록합니다.
-    register_theme_statics(app)
+    TemplateService.register_statics(app)
 
     # 이전 테마 경로를 제거 후 새로운 테마 경로를 추가합니다.
     user_template = UserTemplates()

--- a/core/exception.py
+++ b/core/exception.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, Optional
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse, RedirectResponse
-from fastapi.templating import Jinja2Templates
 from starlette.templating import _TemplateResponse
 
 from slowapi.errors import RateLimitExceeded
@@ -135,13 +134,10 @@ def template_response(
     Returns:
         _TemplateResponse: 템플릿 응답 객체
     """
-    from core.template import TemplateService, theme_asset
+    from core.template import TemplateService
 
-    # 새로운 템플릿 응답 객체를 생성합니다.
-    # - UserTemplates, AdminTemplates 클래스는 기본 컨텍스트 설정 시 DB를 조회하는데,
-    #   처음 설치 시에는 DB가 없으므로 새로운 템플릿 응답 객체를 생성합니다.
-    template = Jinja2Templates(directory=TemplateService.get_templates_dir())
-    template.env.globals["theme_asset"] = theme_asset
+    # UserTemplates/AdminTemplates는 DB 조회가 필요하므로 사용하지 않는다.
+    template = TemplateService.get_templates()
     return template.TemplateResponse(
         name=template_html,
         context=context,

--- a/lib/board_lib.py
+++ b/lib/board_lib.py
@@ -6,7 +6,6 @@ from datetime import datetime, timedelta
 import bleach
 from typing import List
 from fastapi import Request
-from fastapi.templating import Jinja2Templates
 from sqlalchemy import and_, asc, desc, func, insert, or_, select
 from sqlalchemy.sql.expression import Select
 from sqlalchemy.orm import Session
@@ -674,8 +673,7 @@ def send_write_mail(request: Request, board: Board, write: WriteBaseModel, origi
     """
     with DBConnect().sessionLocal() as db:
         config = request.state.config
-        templates = Jinja2Templates(
-                directory=TemplateService.get_templates_dir())
+        templates = TemplateService.get_templates()
 
         def _add_admin_email(admin_id: str):
             admin = db.scalar(select(Member).filter_by(mb_id=admin_id))

--- a/lib/mail.py
+++ b/lib/mail.py
@@ -10,7 +10,6 @@ from email.mime.text import MIMEText
 from email.utils import formataddr
 
 from fastapi import Request
-from fastapi.templating import Jinja2Templates
 
 from core.database import DBConnect
 from core.models import Config, Member, PollEtc, QaConfig, QaContent
@@ -88,8 +87,7 @@ async def send_password_reset_mail(request: Request, member: Member) -> None:
         request.state.config = config = db.query(Config).first()
 
     try:
-        templates = Jinja2Templates(
-            directory=TemplateService.get_templates_dir())
+        templates = TemplateService.get_templates()
 
         subject = f"[{config.cf_title}] 요청하신 비밀번호 찾기 메일입니다."
         body = templates.TemplateResponse(
@@ -117,7 +115,7 @@ async def send_register_mail(request: Request, member: Member) -> None:
         request.state.config = config = db.query(Config).first()
 
     try:
-        templates = Jinja2Templates(directory=TemplateService.get_templates_dir())
+        templates = TemplateService.get_templates()
         from_email = get_admin_email(request)
         from_name = get_admin_email_name(request)
         context = {"request": request, "member": member}
@@ -154,8 +152,7 @@ async def send_register_admin_mail(request: Request, member: Member) -> None:
         request.state.config = config = db.query(Config).first()
 
     try:
-        templates = Jinja2Templates(
-            directory=TemplateService.get_templates_dir())
+        templates = TemplateService.get_templates()
         from_email = get_admin_email(request)
         from_name = get_admin_email_name(request)
         context = {"request": request, "member": member}
@@ -185,8 +182,7 @@ async def send_poll_etc_mail(request: Request, poll_etc: PollEtc) -> None:
 
     try:
         if config.cf_email_po_super_admin and config.cf_admin_email:
-            templates = Jinja2Templates(
-                directory=TemplateService.get_templates_dir())
+            templates = TemplateService.get_templates()
             email = get_admin_email(request)
             from_name = get_admin_email_name(request)
             subject = f"[{config.cf_title}] 설문조사 - 기타의견 메일"
@@ -223,8 +219,7 @@ async def send_qa_mail(request: Request, qa: QaContent) -> None:
     from_name = get_admin_email_name(request)
     subject = f"[{config.cf_title}] {qa_config.qa_title} 질문 알림 메일"
     content = qa.qa_subject + "<br><br>" + qa.qa_content
-    templates = Jinja2Templates(
-                directory=TemplateService.get_templates_dir())
+    templates = TemplateService.get_templates()
 
     if qa.qa_parent:
         question = db.get(QaContent, qa.qa_parent)

--- a/main.py
+++ b/main.py
@@ -21,7 +21,7 @@ from core.plugin import (
 )
 from core.routers import router as template_router
 from core.settings import ENV_PATH, settings
-from core.template import register_theme_statics
+from core.template import TemplateService
 from lib.common import (
     get_client_ip, is_intercept_ip, is_possible_ip, session_member_key
 )
@@ -66,7 +66,7 @@ if not os.path.exists("data"):
     os.mkdir("data")
 
 # 각 경로에 있는 파일들을 정적 파일로 등록합니다.
-register_theme_statics(app)
+TemplateService.register_statics(app)
 app.mount("/static", StaticFiles(directory="static"), name="static")
 app.mount("/data", StaticFiles(directory="data"), name="data")
 


### PR DESCRIPTION
## Summary
- extend `TemplateService` to create templates and mount static directories
- update modules to use new `TemplateService` API

## Testing
- `python -m py_compile core/template.py core/exception.py lib/mail.py lib/board_lib.py main.py admin/admin_theme.py`

------
https://chatgpt.com/codex/tasks/task_e_684130294948832baacb2d174bd35669